### PR TITLE
Fix placeholder color in the input

### DIFF
--- a/src/components/core/Input/Input.js
+++ b/src/components/core/Input/Input.js
@@ -22,6 +22,10 @@ const Input = styled.input`
 	/* Remove red outline on required input in Firefox */
 	box-shadow: none;
 
+	&::placeholder {
+		color: ${themeGet('colors.secondary')};
+	}
+
 	&:focus {
 		outline: 0;
 		box-shadow: 0 0 0 2px ${themeGet('colors.focus')};


### PR DESCRIPTION
Fixes the color of the placeholder text to match border color of the input. Especially noticeably in the dark theme.