### PR TITLE
Fix: Text component default font

### DIFF
--- a/src/components/core/Text/Text.js
+++ b/src/components/core/Text/Text.js
@@ -13,7 +13,7 @@ const Text = styled.p`
 	margin: 0;
 	font-weight: normal;
 	line-height: ${props => props.theme.lineHeights.base};
-	font-family: ${props => props.theme.fonts.base};
+	font-family: ${props => props.theme.fonts.body};
 	text-align: ${props => props.align};
 	list-style-type: none;
 	${textStyle};
@@ -22,6 +22,7 @@ const Text = styled.p`
 Text.propTypes = {
 	/** Custom component or HTML tag */
 	as: PropTypes.oneOfType([PropTypes.element, PropTypes.string]),
+
 	/** Variation */
 	variant: PropTypes.oneOf(['base', 'secondary', 'tertiary', 'error']),
 	align: PropTypes.oneOf(['left', 'center', 'right']),


### PR DESCRIPTION
This fixes the usage of a wrong design token (`body` instead of `base`)