### PR TITLE
Build: Add homepage field to the package.json 

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
 	"version": "0.1.0",
 	"private": true,
 	"license": "MIT",
+	"homepage": "https://cdds.netlify.com",
 	"dependencies": {
 		"@component-driven/react-design-tokens": "^1.1.1",
 		"@reach/router": "^1.2.1",


### PR DESCRIPTION
to get absolute URLs for assets

Fixes when used with rewrite rules on netlify

See https://create-react-app.dev/docs/deployment for more information